### PR TITLE
Removed '#' links from Product Name in Product Details Page

### DIFF
--- a/app/views/product.html
+++ b/app/views/product.html
@@ -47,14 +47,14 @@
 					<div class="row visible-md visible-lg">
 						<div class="col-xs-12">
 							<div class="th-product-details__title">
-								<a href="#"><span itemprop="name" data-ng-bind="product.name"></span></a>
+								<span itemprop="name" data-ng-bind="product.name"></span>
 							</div>
 						</div><!-- .product name -->
 					</div>
 					<div class="row">
 						<div class="col-xs-12 col-md-6">
 							<div class="th-product__name visible-xs">
-								<a href="#"><span itemprop="name" data-ng-bind="product.name"></span></a>
+								<span itemprop="name" data-ng-bind="product.name"></span>
 							</div>
 							<div class="th-product__price--large">
 								<span class="th-reg-price" data-ng-show="product.price.regularPrice > 0"><span class="th-price" data-ng-class="{strike: product.price.salePrice > 0}"><span itemprop="price" data-ng-bind="product.price.regularPrice | currency"></span></span><span class="th-price-text th-text-left" data-translate="product.regularPriceLabel">Reg</span></span>


### PR DESCRIPTION
@hippee-lee, @texasag, @tsanko, small change to the product html page to remove the empty (#) links on the Product Name which was taking the user back to the home page
