### PR TITLE
Fix livereload. Thanks @tsanko for identifying the culprit.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -361,7 +361,7 @@ module.exports = function(grunt) {
 				collapseWhitespace: true,
 				collapseBooleanAttributes: true,
 				removeCommentsFromCDATA: true,
-				removeOptionalTags: true
+//				removeOptionalTags: true // This option breaks livereload when used.
 			},
 			server: {
 				files: [


### PR DESCRIPTION
@kevinsproles @texasag @prabinv 

Picking up where I left off Tsanko found a culprit in the Grunfile that was causing the live reload scripts to go missing from the index file. Beers and other spoils of war should go his way. If you are curious as the the mechanics please ping one of us for further discussion. 

@tsanko for completeness. 
