### PR TITLE
Adjusted product layout for laptop/md viewports

### DIFF
--- a/app/views/category.html
+++ b/app/views/category.html
@@ -41,7 +41,7 @@
 			</div>
 
 			<div class="row">
-				<div class="-product-tile-animation col-sm-6 col-md-3" data-ng-repeat="product in products">
+				<div class="-product-tile-animation col-sm-6 col-md-4 col-lg-3" data-ng-repeat="product in products">
 					<div class="th-product">
 						<span class="th-product__sale" data-ng-show="product.isOnSale"></span>
 						<span class="th-product__new" data-ng-show="product.isNew"></span>

--- a/app/views/search.html
+++ b/app/views/search.html
@@ -43,7 +43,7 @@
 			</div>
 
 			<div class="row">
-				<div class="-product-tile-animation col-sm-6 col-md-3" data-ng-repeat="product in products">
+				<div class="-product-tile-animation col-sm-6 col-md-4 col-lg-3" data-ng-repeat="product in products">
 					<div class="th-product">
 						<span class="th-product__sale" data-ng-show="product.isOnSale"></span>
 						<span class="th-product__new" data-ng-show="product.isNew"></span>


### PR DESCRIPTION
@texasag @prabinv 
### Adjust Bootstrap's grid for laptop/md viewports
- 3 products per column instead of 4
  - Search page
  - Category page
- This will help prevent product title text overflowing onto the product price inside the md breakpoint as an alternative to lots of media queries with CSS.

TODO: Prevent text overflow in related products row on product page inside md breakpoint
