### PR TITLE
Added logic to display errors and warnings

### DIFF
--- a/app/scripts/controllers/product.js
+++ b/app/scripts/controllers/product.js
@@ -368,6 +368,29 @@ angular.module('Volusion.controllers')
 				return path;
 			};
 
+            function displayCartMessages(res) {
+                var vnMsg;
+                var translateFilter = $filter('translate');
+
+                if (res.serviceErrors && res.serviceErrors.length > 0) {
+                    angular.forEach(res.serviceErrors, function(error) {
+                        vnMsg = translateFilter(error.Code);
+                        vnMsg = (vnMsg === error.Code) ? error.Message : vnMsg;
+                        $rootScope.$emit('vnNotification.show', { type: 'danger', msg: vnMsg });
+                    });
+                }
+                else if (res.warnings && res.warnings.length > 0 ) {
+                    angular.forEach(res.warnings, function(warning) {
+                        vnMsg = translateFilter(warning.Code);
+                        vnMsg = (vnMsg === warning.Code) ? warning.Message : vnMsg;
+                        $rootScope.$emit('vnNotification.show', { type: 'warning', msg: vnMsg });
+                    });
+                } else {
+                    vnMsg = translateFilter('message.addToCartSuccess');
+                    $rootScope.$emit('vnNotification.show', { type: 'success', msg: vnMsg });
+                }
+            }
+
 			$scope.addToCart = function() {
 
 
@@ -378,39 +401,13 @@ angular.module('Volusion.controllers')
 				}
 
 				Cart.saveCart($scope.cartItem)
-					.then(function () {
+					.then(function (response) {
 						$scope.cartItem.qty = 0;
-
-						var vnMsg = $filter('translate')('message.addToCartSuccess');
-						$rootScope.$emit('vnNotification.show', { type: 'success', msg: vnMsg });
+                        displayCartMessages(response.data);
 
 					}, function (response) {
-						var vnMsg = '';
-
-                        if (response.errors && response.errors.length > 0) {
-                        	// Multiple error handling ?
-							try {
-								// vnMsg = $filter('translate')('message.addToCartError');
-								vnMsg = $filter('translate')('message.' + response.errors);
-							} catch (ex) {
-								vnMsg = $filter('translate')('message.unknown');
-							}
-                            $rootScope.$emit('vnNotification.show', { type: 'danger', msg: vnMsg });
-                        }
-                        if (response.warnings && response.warnings.length > 0) {
-							// Multiple warning handling ?
-							try {
-								// vnMsg = $filter('translate')('message.addToCartWarning');
-								vnMsg = $filter('translate')('message.' + response.errors);
-							} catch (ex) {
-								vnMsg = $filter('translate')('message.unknown');
-							}
-							$rootScope.$emit('vnNotification.show', { type: 'warning', msg: vnMsg });
-                        }
-//						$rootScope.$emit('VN_ADD_TO_CART_FAIL', {
-//							status: status,
-//							data  : cartItem
-//						});
+                        $scope.cartItem.qty = 0;
+                        displayCartMessages(response.data);
 					})
 					.finally(function () {
 						modifyQuantity(1);

--- a/app/translations/message/en.json
+++ b/app/translations/message/en.json
@@ -1,9 +1,22 @@
 {
-	"message": {
-		"addToCartSuccess": "Item(s) are added to your cart",
-		"addToCartError"  : "ERROR!",
-		"addToCartWarning": "Warning!",
+    "message": {
+        "addToCartSuccess": "Item(s) are added to your cart",
+        "addToCartError"  : "ERROR!",
+        "addToCartWarning": "Warning!",
 
-		"unknown" 		  : "Unknown server error"
-	}
+        "unknown" 		  : "Unknown server error",
+        "CART_ITEM_UNAVAILABLE": "",
+        "CART_ITEM_WITH_OPTION_UNAVAILABLE": "",
+        "CART_MAX_ITEM_COUNT_EXCEEDED": "",
+        "CART_ITEM_MIN_ORDER_QTY": "",
+        "CART_ITEM_MAX_ORDER_QTY": "",
+        "CART_ITEM_PREVIOUSLY_ADDED_UNAVAILABLE": "",
+        "CART_ITEM_MINQTY_UNAVAILABLE": "",
+        "CART_ITEM_QTY_ADJUSTED_TO_AVAILABILITY": "",
+        "CART_ITEM_OUT_OF_STOCK": "",
+        "CART_KITITEM_MINQTY_UNAVAILABLE": "",
+        "CART_KITITEM_QTY_ADJUSTED_TO_AVAILABILITY": "",
+        "CART_KITITEM_NO_AVAILABLE_STOCK": "",
+        "CART_KITITEM_OUT_OF_STOCK": ""
+    }
 }


### PR DESCRIPTION
@tsanko Here are the client side changes for displaying errors and warning from Cart. I'm deploying the server side changes to samplestore.io now.
In the next iteration, I want to support messages in the translate file with place holders which can be replaced with the data. I also want to abstract out the displayCartMessages function into a service, and add some tests.

TargetProcess Id - 28394
