### PR TITLE
fixed grunt build to dist

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -582,6 +582,7 @@ module.exports = function(grunt) {
 			'ngAnnotate',
 			'copy:dist',
 			'cssmin',
+			'uglify',
 			'rev',
 			'usemin',
 			'htmlmin:dist'


### PR DESCRIPTION
- wasn't copying /scripts folder. Reason was we removed the uglify task, added it back. Uglify doesn't need to be configured just needs to run the task interestingly enough.
