### PR TITLE
Displays the server error modal on HTTP 500 errors

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -115,8 +115,8 @@ angular.module('methodApp', [
 					redirectTo: '/'
 				});
 		}])
-	.run(['snapRemote', '$rootScope', '$window', 'cacheBustFilter', 'SiteConfig', 'themeSettings', 'vnCart', 'ContentMgr', 'translate',
-		function (snapRemote, $rootScope, $window, cacheBustFilter, SiteConfig, themeSettings, vnCart, ContentMgr, translate) {
+	.run(['snapRemote', '$rootScope', '$window', 'cacheBustFilter', 'SiteConfig', 'themeSettings', 'vnCart', 'ContentMgr', 'translate', 'vnErrorModalService',
+		function (snapRemote, $rootScope, $window, cacheBustFilter, SiteConfig, themeSettings, vnCart, ContentMgr, translate, vnErrorModalService) {
 
 			'use strict';
 
@@ -150,6 +150,10 @@ angular.module('methodApp', [
 			$rootScope.$on('$routeChangeSuccess', function () {
 				snapRemote.close();
 			});
+
+            $rootScope.$on('VN_HTTP_500_ERROR', function() {
+                vnErrorModalService.showError('views/server-error.html');
+            });
 
 			$rootScope.$watch(
 				// Use a fn in $watch first argument that gets value from service

--- a/app/translations/messages/en.json
+++ b/app/translations/messages/en.json
@@ -14,6 +14,9 @@
 		"CART_KITITEM_MINQTY_UNAVAILABLE"          : "",
 		"CART_KITITEM_QTY_ADJUSTED_TO_AVAILABILITY": "",
 		"CART_KITITEM_NO_AVAILABLE_STOCK"          : "",
-		"CART_KITITEM_OUT_OF_STOCK"                : ""
+		"CART_KITITEM_OUT_OF_STOCK"                : "",
+        "SERVER_ERROR_HEADING"                      : "Sorry, something went wrong with the page...",
+        "SERVER_ERROR_SECTION1"                     : "... but it might just be a small glitch. Try refreshing the page to see if that fixes it.",
+        "SERVER_ERROR_SECTION2"                     : "If the problem persists, please try again later."
 	}
 }

--- a/app/views/server-error.html
+++ b/app/views/server-error.html
@@ -1,0 +1,14 @@
+<div class="th-error-wrap clearfix">
+    <div class="th-error-details">
+        <div class="th-error-details__header modal-header">
+            <h1 data-translate="message.SERVER_ERROR_HEADING"></h1>
+            <div class="modal-body">
+                <p class="th-error-details__section1" data-translate="message.SERVER_ERROR_SECTION1"></p>
+                <p class="th-error-details__section2" data-translate="message.SERVER_ERROR_SECTION2"></p>
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-warning" ng-click="$close()">Close</button>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
@hippee-lee @tsanko @kevinsproles Changes to display the server error  modal window when there is an HTTP 500 error event on the rootScope.

Please update the TargetProcess story [23810](http://targetprocess/RestUI/Board.aspx?acid=E1D9755C8F06DC3E65078C412790423E#page=userstory/23810&appConfig=eyJhY2lkIjoiMzVCOTE5ODUwMUM0NTE3MzUzQTYxQTRBMUQ4M0UxQTQifQ==) after this is pulled in.
