### PR TITLE
Console returns a number, .search deals in string.

### DIFF
--- a/app/scripts/directives/paginator.js
+++ b/app/scripts/directives/paginator.js
@@ -29,10 +29,12 @@ angular.module('Volusion.directives')
 				};
 
 				scope.$watch(attrs.cursor, function (value) {
+
 					if (value === undefined) {
 						return;
 					}
-					scope.currentPage = value.currentPage;
+
+					scope.currentPage = value.currentPage.toString();
 					vnProductParams.setPage(scope.currentPage);
 				}, true);
 			}


### PR DESCRIPTION
This PR is related to the corresponding pr for the toolbox.
The api retunes page as in int but $location.search uses/converts it to a string. Rather that writing a bunch of ugly is it string, is it int and what value is it in the tool box I just convert it to a string when the api hands it to the app. 

Note on the log message: it should be $location.search but the command line or git ate my $location. 

@prabinv , @texasag please code review. 
