### PR TITLE
Fixed the articles route

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -114,7 +114,12 @@ angular.module('methodApp', [
 			// Articles must be last or the prior /search and /theme-settings will never be picked up
 			.when('/:slug', {
 				templateUrl: 'views/article.html',
-				controller : 'ArticleCtrl'
+				controller : 'ArticleCtrl',
+                resolve: {
+                    article: ['vnApi', '$route', function(vnApi, $route) {
+                        return vnApi.Article().get({slug: $route.current.params.slug}).$promise;
+                    }]
+                }
 			})
 			.otherwise({
 				redirectTo: '/'
@@ -144,11 +149,11 @@ angular.module('methodApp', [
             }
         }]);
 
-		$rootScope.$on('$routeChangeSuccess', function () {
-			snapRemote.close();
-		});
+        $rootScope.$on('$routeChangeSuccess', function () {
+            snapRemote.close();
+        });
 
-		$rootScope.$on('VN_HTTP_500_ERROR', function () {
+        $rootScope.$on('VN_HTTP_500_ERROR', function () {
 			vnModalService.showError('views/server-error.html');
 		});
 

--- a/app/scripts/controllers/article.js
+++ b/app/scripts/controllers/article.js
@@ -1,14 +1,10 @@
 angular.module('Volusion.controllers')
 	.controller('ArticleCtrl', [
-		'$rootScope', '$scope', '$routeParams', 'vnApi',
-		function ($rootScope, $scope, $routeParams, vnApi) {
-
+		'$rootScope', '$scope', 'article',
+		function ($rootScope, $scope,  article) {
 			'use strict';
 
-			vnApi.Article().get({ slug: 'how-do-i-return-an-item' }).$promise
-				.then(function (response) {
-					$scope.article = response.data;
-					$rootScope.seo = angular.extend($rootScope.seo || {}, $scope.article.seo);
-				});
+            $scope.article = article.data;
+            $rootScope.seo = angular.extend($rootScope.seo || {}, $scope.article.seo);
 		}
 	]);


### PR DESCRIPTION
@hippee-lee This is a fix to the articles route which was using a hard coded slug value. Thought I'd get this into master and sprint7 before you go ahead with the renaming of articles to "pages".
